### PR TITLE
Data scraping fail

### DIFF
--- a/scraping.py
+++ b/scraping.py
@@ -2,6 +2,8 @@
 # *-encoding: utf8 -*
 
 
+#update 10/15/2021 The web site have been changed and some of the end points calls will fail when try to retrieve data.
+
 import datetime
 import requests as rqs
 from bs4 import BeautifulSoup


### PR DESCRIPTION
The web site have been changed and some of the element that were configured in the scraper are no longer there. Therefore, the scraper fails when try to retrieve the data and create a empty data frame.